### PR TITLE
add y,x params to status message

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <signal.h>
+#include <string.h>
 #include <curses.h>
 
 #include "main.h"
@@ -104,9 +105,9 @@ int main(int argc, char** argv) {
     loop_ch = getch();
     if (loop_ch != ERR) {
       if (command_line_params.pthreads == 1) {
-        pthread_update_status(loop_ch);
+        pthread_update_status(LINES/2, strlen(verbose_prompt) + 1, loop_ch);
       } else {
-        thrd_update_status(loop_ch);
+        thrd_update_status(LINES/2, strlen(verbose_prompt) + 1, loop_ch);
       }
       switch (loop_ch) {
         case 'q': {

--- a/src/main.h
+++ b/src/main.h
@@ -30,6 +30,5 @@
 
 extern bool    exit_program;
 extern uint8_t time_index;
-extern const char * verbose_prompt;
 
 #endif

--- a/src/pthread.c
+++ b/src/pthread.c
@@ -16,7 +16,6 @@
 #include <signal.h>
 #include <curses.h>
 #include <errno.h>
-#include <string.h>
 
 #include "main.h"
 #include "process_command_line.h"
@@ -107,11 +106,11 @@ void* update_seconds(void *arg) {
  *
  * @return nothing
  */
-void pthread_update_status(char ch) {
+void pthread_update_status(int y,  int x, char ch) {
 
   pthread_mutex_lock(&p_screen_lock);
   attroff(COLOR_PAIR(1));
-  mvwprintw(stdscr, LINES/2, strlen(verbose_prompt) + 1, "%c", ch);
+  mvwprintw(stdscr, y, x, "%c", ch);
   attron(COLOR_PAIR(1));
   refresh();
   pthread_mutex_unlock(&p_screen_lock);

--- a/src/pthread.h
+++ b/src/pthread.h
@@ -12,6 +12,6 @@
 #define _PTHREAD_H
 
 extern int pthread_start();
-extern void pthread_update_status(char ch);
+extern void pthread_update_status(int y, int x, char ch);
 
 #endif

--- a/src/thrd.c
+++ b/src/thrd.c
@@ -12,7 +12,6 @@
 #include <signal.h>
 #include <threads.h>
 #include <ncurses.h>
-#include <string.h>
 
 #include "main.h"
 #include "process_command_line.h"
@@ -78,11 +77,11 @@ int t_update_seconds(void *arg) {
  * @return  nothing
  *
  */
-void thrd_update_status(char ch) {
+void thrd_update_status(int y, int x, char ch) {
 
   mtx_lock(&t_screen_lock);
   attroff(COLOR_PAIR(1));
-  mvwprintw(stdscr, LINES/2, strlen(verbose_prompt) + 1, "%c", ch);
+  mvwprintw(stdscr, y, x, "%c", ch);
   attron(COLOR_PAIR(1));
   refresh();
   mtx_unlock(&t_screen_lock);

--- a/src/thrd.h
+++ b/src/thrd.h
@@ -11,6 +11,6 @@
 #define _THRD_H
 
 extern int thrd_start();
-extern void thrd_update_status(char ch);
+extern void thrd_update_status(int y, int x, char ch);
 
 #endif


### PR DESCRIPTION
removes the need for the threads to have information about the prompt lenght